### PR TITLE
Update map information retrieval in remoteMapInstanceManager

### DIFF
--- a/BHD-RemoteClient/Classes/InstanceManagers/remoteMapInstanceManager.cs
+++ b/BHD-RemoteClient/Classes/InstanceManagers/remoteMapInstanceManager.cs
@@ -25,15 +25,17 @@ namespace BHD_RemoteClient.Classes.InstanceManagers
             {
                 if (row.IsNewRow) continue;
 
-                string? mapName = row.Cells["MapName"].Value?.ToString();
-                string? gameType = row.Cells["MapType"].Value?.ToString();
+                string? mapName = row.Cells["current_MapName"].Value?.ToString();
+                string? gameType = row.Cells["current_MapType"].Value?.ToString();
+                string? mapFile = row.Cells["current_MapFileName"].Value?.ToString();
 
                 if (string.IsNullOrWhiteSpace(mapName) || string.IsNullOrWhiteSpace(gameType))
                     continue;
 
                 var map = instanceMaps.availableMaps
                     .FirstOrDefault(m => string.Equals(m.MapName, mapName, StringComparison.OrdinalIgnoreCase)
-                                      && string.Equals(m.MapType, gameType, StringComparison.OrdinalIgnoreCase));
+                                        && string.Equals(m.MapFile, mapFile, StringComparison.OrdinalIgnoreCase)
+                                        && string.Equals(m.MapType, gameType, StringComparison.OrdinalIgnoreCase));
 
                 if (map == null)
                     continue;


### PR DESCRIPTION
Changed column names for map name and game type to "current_MapName" and "current_MapType". Introduced a new variable `mapFile` to access "current_MapFileName". Updated map matching logic to include `mapFile` in the comparison with available maps.